### PR TITLE
Tests: Performance, only run mypy on oldest and latetest python

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -122,7 +122,7 @@ def safety(session: nox.Session) -> None:
     session.run("safety", "check", "--full-report", f"--file=requirements.txt", env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}, external=True)
 
 
-@nox.session(python=python_versions)
+@nox.session(python=[python_versions[0], python_versions[-1]])
 def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]


### PR DESCRIPTION
Running mypy tests on the middle versions is not usefull.