### PR TITLE
feat: Add link checker to cookiecutter projects

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Check documentation
+on: [push, pull_request]
+
+jobs:
+  docs:
+    name: Build documentation & check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+      - name: Create uv environment
+        run: uv venv
+      - name: Install dependencies
+        run: |
+          uv pip install --constraint=.github/workflows/constraints.txt pip
+          uv pip install --constraint=.github/workflows/constraints.txt nox
+      - name: Build documentation
+        run: uv run nox --force-color --session=docs-build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: docs/_build
+      - name: Check links
+        continue-on-error: true
+        run: uv run nox --force-color --session=docs-linkcheck

--- a/{{cookiecutter.project_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/docs.yml
@@ -1,29 +1,40 @@
 name: Check documentation
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
 
 jobs:
   docs:
     name: Build documentation & check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Check out the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          python-version: "3.12"
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v1
-      - name: Create uv environment
-        run: uv venv
-      - name: Install dependencies
-        run: |
-          uv pip install --constraint=.github/workflows/constraints.txt pip
-          uv pip install --constraint=.github/workflows/constraints.txt nox
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
       - name: Build documentation
         run: uv run nox --force-color --session=docs-build
-      - uses: actions/upload-artifact@v4
+      - name: Upload documentation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs
           path: docs/_build
+      # Link checking hits live external URLs, which flake (timeouts, redirects,
+      # bot-blocking). Keep it non-blocking so a dead link never blocks a merge.
       - name: Check links
         continue-on-error: true
         run: uv run nox --force-color --session=docs-linkcheck

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -32,7 +32,6 @@ nox.options.sessions = (
     "typeguard",
     "xdoctest",
     "docs-build",
-    "docs-linkcheck",
 )
 
 

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -303,20 +303,10 @@ def docs_linkcheck(session: nox.Session) -> None:
         "uv",
         "sync",
         "--group",
-        "dev",
-        "--group",
         "docs",
         external=True,
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
-    session.install(
-        "sphinx",
-        "sphinx-mermaid",
-        "sphinx-click",
-        "myst_parser",
-        "shibuya",
-        "sphinx-copybutton",
-    )
-    session.install("-e", ".")
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():


### PR DESCRIPTION
This commit introduces a link checker to the generated cookiecutter projects.

The link checker is implemented as a nox session named `docs-linkcheck` and is integrated into a new GitHub Actions workflow.

The key features are:
- A new `docs-linkcheck` nox session in `noxfile.py`.
- A new GitHub workflow `docs.yml` that builds the documentation and runs the link checker.
- The link checker is non-blocking and will only show a warning for broken links, thanks to the `--keep-going` flag in the nox session and `continue-on-error: true` in the workflow.