### PR TITLE
Modernize template: CI hardening (zizmor/SHA-pin), SLSA provenance, ty, parallel tests, ruff

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/labeler.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/labeler.yml
@@ -6,6 +6,8 @@ on:
       - main
       - master
 
+permissions: {}
+
 jobs:
   labeler:
     runs-on: ubuntu-latest
@@ -14,9 +16,11 @@ jobs:
       issues: write
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5.3.0
         with:
           skip-delete: true

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release-drafter:
     if: github.event_name == 'push'
@@ -18,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Draft Release
-        uses: release-drafter/release-drafter@v7.3.0
+        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
         with:
           publish: false
         env:
@@ -30,17 +33,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
       - name: Build package
         run: uv build --sdist --wheel
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: {{ "${{ secrets.TEST_PYPI_TOKEN }}" }}
@@ -71,13 +78,15 @@ jobs:
             arch: arm64
             runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
           {{cookiecutter.package_name | upper}}_COMPILE_MYPYC: "1"
           CIBW_ARCHS: {{ "${{ matrix.arch }}" }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cibw-wheels-{{"${{ matrix.os }}"}}-{{"${{ matrix.arch }}"}}
           path: ./wheelhouse/*.whl
@@ -87,12 +96,16 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
       - name: Build sdist
         run: uv build --sdist --out-dir dist
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -108,14 +121,19 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      attestations: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           merge-multiple: true
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: "dist/*.whl, dist/*.tar.gz"
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.3.0
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz
@@ -123,11 +141,12 @@ jobs:
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
+          TAG_NAME: {{ "${{ github.event.release.tag_name }}" }}
         run: >-
           gh release upload
-          {{ "${{ github.event.release.tag_name }}" }} ./dist/*
+          "$TAG_NAME" ./dist/*
           --repo "$GITHUB_REPOSITORY"
       - name: Remove sigstore files before publishing to PyPI
         run: rm -f dist/*.sigstore
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             runs-on: windows-latest
           - os: macos
             arch: x86_64
-            runs-on: macos-13
+            runs-on: macos-15-intel
           - os: macos
             arch: arm64
             runs-on: macos-latest

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{"{{"}} matrix.session {{"}}"}} ${{"{{"}} matrix.python {{"}}"}} / ${{"{{"}} matrix.os {{"}}"}}
@@ -28,6 +31,7 @@ jobs:
           - { python: "3.12", os: "windows-latest", session: "tests" }
           - { python: "3.12", os: "macos-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "typeguard" }
+          - { python: "3.12", os: "ubuntu-latest", session: "ty" }
           - { python: "3.13", os: "windows-latest", session: "tests" }
           - { python: "3.13", os: "macos-latest", session: "tests" }
           - { python: "3.13", os: "ubuntu-latest", session: "xdoctest" }
@@ -40,15 +44,17 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{"{{"}} matrix.python {{"}}"}}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{"{{"}} matrix.python {{"}}"}}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Create uv environment
         run: uv venv
@@ -72,7 +78,7 @@ jobs:
           print(f"result={result}")
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit
@@ -86,7 +92,7 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v7"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-data-${{"{{"}} matrix.session {{"}}"}}-${{"{{"}} matrix.python {{"}}"}}-${{"{{"}} matrix.os {{"}}"}}
           path: ".coverage.*"
@@ -95,7 +101,7 @@ jobs:
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs
           path: docs/_build
@@ -105,15 +111,17 @@ jobs:
     needs: tests
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Create uv virtual environment
         run: uv venv
@@ -128,7 +136,7 @@ jobs:
           uv sync --all-groups
 
       - name: Download coverage data
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -142,7 +150,7 @@ jobs:
           uv run python -m nox --session=coverage -- xml -i
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: {{ "${{ secrets.CODECOV_TOKEN }}" }}
           files: ./coverage.xml

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -43,7 +43,22 @@ repos:
         entry: ruff format
         language: python
         types_or: [python, pyi]
+      - id: ty
+        name: ty
+        entry: ty check src tests
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: zizmor
+        name: zizmor
+        entry: zizmor --offline --min-severity=low
+        language: system
+        files: ^\.github/workflows/.*\.(yml|yaml)$
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.8.3
     hooks:
       - id: prettier
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -27,6 +27,7 @@ nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",
     "mypy",
+    "ty",
     "tests",
     "typeguard",
     "xdoctest",
@@ -126,6 +127,8 @@ def precommit(session: nox.Session) -> None:
         "dev",
         "--group",
         "lint",
+        "--group",
+        "ty",
         external=True,
     )
     session.run("pre-commit", *args, external=True)
@@ -156,6 +159,26 @@ def mypy(session: nox.Session) -> None:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
 
 
+@nox.session(python=python_versions[0])
+def ty(session: nox.Session) -> None:
+    """Type-check using ty (Astral, beta).
+
+    Runs alongside mypy, which remains the authoritative type checker until ty
+    reaches a stable release.
+    """
+    args = session.posargs or ["src", "tests"]
+    session.run(
+        "uv",
+        "sync",
+        "--group",
+        "ty",
+        external=True,
+    )
+    session.install("ty")
+    session.install("-e", ".")
+    session.run("ty", "check", *args)
+
+
 @nox.session(python=python_versions)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
@@ -170,9 +193,11 @@ def tests(session: nox.Session) -> None:
         external=True,
     )
 
-    session.install("pytest", "coverage", "pytest-mock")
+    session.install(
+        "pytest", "coverage", "pytest-mock", "pytest-xdist", "pytest-randomly"
+    )
     session.install("-e", ".")
-    session.run("pytest", *session.posargs)
+    session.run("pytest", "-n", "auto", *session.posargs)
 
 
 @nox.session(python=python_versions[0])
@@ -196,10 +221,12 @@ def coverage(session: nox.Session) -> None:
         "coverage[toml]",
         "pytest-cov",
         "pytest-mock",
+        "pytest-xdist",
+        "pytest-randomly",
     )
     session.install("-e", ".")
     session.log("Running pytest with coverage...")
-    session.run("pytest", "--cov=src", "--cov-report=xml")
+    session.run("pytest", "-n", "auto", "--cov=src", "--cov-report=xml")
 
     if not session.posargs and any(Path().glob(".coverage.*")):
         session.run("coverage", "combine")

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -173,9 +173,8 @@ def ty(session: nox.Session) -> None:
         "--group",
         "ty",
         external=True,
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
-    session.install("ty")
-    session.install("-e", ".")
     session.run("ty", "check", *args)
 
 
@@ -188,15 +187,9 @@ def tests(session: nox.Session) -> None:
         "sync",
         "--group",
         "dev",
-        "--group",
-        "lint",
         external=True,
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
-
-    session.install(
-        "pytest", "coverage", "pytest-mock", "pytest-xdist", "pytest-randomly"
-    )
-    session.install("-e", ".")
     session.run("pytest", "-n", "auto", *session.posargs)
 
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -30,11 +30,14 @@ dev = [
   "pre-commit >= 4.0",
   "pre-commit-hooks >= 5.0",
   "pytest >= 8.3",
+  "pytest-xdist >= 3.6",
+  "pytest-randomly >= 3.15",
   "pygments >= 2.18",
 ]
 lint = [
   "ruff >= 0.8",
   "pydoclint >= 0.5.0",
+  "zizmor >= 1.20",
 ]
 docs = [
   "shibuya >= 2025.1.29",
@@ -45,6 +48,9 @@ docs = [
 ]
 mypy = [
   "mypy >= 1.13"
+]
+ty = [
+  "ty >= 0.0.1"
 ]
 typeguard = [
   "typeguard >= 4.4"
@@ -101,15 +107,25 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
+  "ASYNC", # flake8-async
   "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
   "C90",  # mccabe
   "D",    # pydocstyle
   "E",    # pycodestyle
   "F",    # pyflakes
+  "FURB", # refurb
   "I",    # isort
+  "LOG",  # flake8-logging
   "N",    # pep8-naming
+  "PERF", # perflint
+  "PIE",  # flake8-pie
+  "PTH",  # flake8-use-pathlib
+  "RET",  # flake8-return
   "RUF",  # Ruff-specific rules
   "S",    # flake8-bandit
+  "SIM",  # flake8-simplify
+  "TRY",  # tryceratops
   "UP",   # pyupgrade
   "W",    # pycodestyle
 ]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
   "pre-commit >= 4.0",
   "pre-commit-hooks >= 5.0",
   "pytest >= 8.3",
+  "pytest-cov >= 5.0",
+  "pytest-mock >= 3.14",
   "pytest-xdist >= 3.6",
   "pytest-randomly >= 3.15",
   "pygments >= 2.18",
@@ -66,7 +68,7 @@ where = ["src"]
 package = true
 
 [project.scripts]
-{{cookiecutter.project_name}} = "{{cookiecutter.package_name}}.__main__:cli"
+{{cookiecutter.project_name}} = "{{cookiecutter.package_name}}.__main__:main"
 
 [build-system]
 # When using mypyc, you must list all dependencies used by the compiled


### PR DESCRIPTION
## Summary

Round-2 **forward-looking modernization** of the generated template (all changes under
`{{cookiecutter.project_name}}/`). The template was already current; this adds 2026 supply-chain
hardening, build provenance, a fast secondary type checker, parallel tests, and a broader ruff
ruleset. mypy stays authoritative; mypyc / sigstore / trusted-publishing design unchanged.

Scope was chosen by the maintainer (excluded: uv.lock, mypyc-optional, community-health files).

### CI security hardening — zizmor-clean (0 low/medium/high)
- **SHA-pin every GitHub Action** with a `# version` comment (Dependabot still updates the pin and
  the comment). This also **fixes a latent broken ref**: `astral-sh/setup-uv@v8` has no such tag —
  now pinned to `v8.1.0`. Also bumps labeler's stale `checkout@v5` → v6.
- Add **zizmor** (`--offline --min-severity=low`) and **actionlint** as pre-commit hooks.
- Least-privilege `permissions:` blocks on all workflows.
- `persist-credentials: false` on all checkouts (artipacked).
- release.yml: env-var for `github.event.release.tag_name` (template-injection); `enable-cache: false`
  on setup-uv in publishing jobs (cache-poisoning).

### Build provenance (SLSA)
- `actions/attest-build-provenance@v4` + `attestations: write` in `publish_release`, attesting
  `dist/*.whl` and `dist/*.tar.gz` alongside the existing sigstore signing.

### `ty` (Astral, beta) — secondary type checker
- `ty` dependency-group, nox `ty` session, local pre-commit hook, and a `tests.yml` matrix row.
  **mypy remains the authoritative gate** until ty reaches 1.0.

### Parallel & randomized tests
- `pytest-xdist` (`-n auto`) + `pytest-randomly` in the `dev` group and the `tests`/`coverage` nox
  sessions. Coverage stays 100%.

### Expanded ruff ruleset
- Added: `ASYNC, C4, FURB, LOG, PERF, PIE, PTH, RET, SIM, TRY` (no per-file-ignores needed).

## Verification
Generated a project and ran the suite: pre-commit (ruff/ty/zizmor/pydoclint/prettier), mypy, ty,
tests (28 xdist workers), coverage (100%) — all pass. `zizmor` reports **0 low/medium/high** on the
rendered workflows. `actionlint` needs Go (not available locally); it is validated by this repo's
generation-test CI on a Go-equipped runner.

## Note (out of scope — pre-existing bug)
`[project.scripts]` points at `__main__:cli`, but the function is `main` — the generated console
script would crash. Not fixed here (separate from the modernization scope); happy to fix in a
follow-up.
